### PR TITLE
Add back Font Dropdown And Other Summenote Fixes

### DIFF
--- a/rush/admin/widgets.py
+++ b/rush/admin/widgets.py
@@ -26,7 +26,7 @@ class SummernoteWidget(SummernoteWidgetBase):
         "toolbar": [
             ["style", ["style"]],
             ["font", ["bold", "underline", "clear"]],
-            # ["fontname", ["fontname"]],
+            ["fontname", ["fontname"]],
             ["color", ["color"]],
             ["para", ["ul", "ol", "paragraph"]],
             # ["table", ["table"]],
@@ -64,6 +64,12 @@ class SummernoteWidget(SummernoteWidgetBase):
                 "className": "rush-hint",
                 "value": "p",
             },
+            "h1",
+            "h2",
+            "h3",
+            "h4",
+            "h5",
+            "h6",
         ],
         "fontNames": [
             "Poppins",

--- a/rush/models/utils.py
+++ b/rush/models/utils.py
@@ -1,3 +1,4 @@
+import html
 from io import BytesIO
 
 import bleach
@@ -115,15 +116,20 @@ class SummernoteTextCleaner:
         "max-height",
         "min-width",
         "min-height",
+        "font-family",
+        "font-weight",
+        "font-size",
     ]
 
     @classmethod
-    def clean(cls, html: str) -> str:
-        return bleach.clean(
-            text=html,
+    def clean(cls, text: str) -> str:
+        unescaped = text.replace("&quot;", "'")
+        cleaned = bleach.clean(
+            text=unescaped,
             attributes=cls.ALLOWED_ATTRIBUTES,
             tags=cls.ALLOWED_TAGS,
             css_sanitizer=bleach.css_sanitizer.CSSSanitizer(
                 allowed_css_properties=cls.BLEACH_ALLOWED_STYLES,
             ),
         )
+        return cleaned

--- a/static/css/rush_summernote.css
+++ b/static/css/rush_summernote.css
@@ -14,34 +14,34 @@ p, h1, h2, h3, h4, h5, h6, .rush-title, .rush-subtitle, .rush-hint {
 
 /* Normal */
 p {
-    font-family: 'Bitter Variable', 'Times New Roman', Times, serif;
+    font-family: Bitter, 'Times New Roman', Times, serif;
     font-weight: 500;
     font-size: 0.875rem;
 }
 
 /* Title */
 .rush-title {
-    font-family: 'Figtree Variable', Arial, Helvetica, sans-serif;
+    font-family: Figtree, Arial, Helvetica, sans-serif;
     font-weight: 700;
     font-size: 2.5rem;
 }
 
 /* Subtitle */
 .rush-subtitle {
-    font-family: 'Urbanist Variable', Arial, Helvetica, sans-serif;
+    font-family: Urbanist, Arial, Helvetica, sans-serif;
     font-weight: 500;
     font-size: 1rem;
 }
 
 /* Hint */
 .rush-hint {
-    font-family: 'Urbanist Variable', Arial, Helvetica, sans-serif;
+    font-family: Urbanist, Arial, Helvetica, sans-serif;
     font-weight: 400;
     font-size: 0.75rem;
 }
 
 h1, h2, h3, h4, h5, h6 {
-    font-family: 'Poppins';
+    font-family: Poppins;
     font-weight: 500;
 }
 
@@ -67,7 +67,7 @@ h1, h2, h3, h4, h5, h6 {
 
 /* bitter-latin-wght-normal */
 @font-face {
-    font-family: 'Bitter Variable';
+    font-family: Bitter;
     font-style: normal;
     font-display: auto;
     font-weight: 100 900;
@@ -76,7 +76,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 /* bitter-latin-wght-italic */
 @font-face {
-    font-family: 'Bitter Variable';
+    font-family: Bitter;
     font-style: italic;
     font-display: auto;
     font-weight: 100 900;
@@ -86,7 +86,7 @@ h1, h2, h3, h4, h5, h6 {
 
 /* urbanist-latin-wght-normal */
 @font-face {
-    font-family: 'Urbanist Variable';
+    font-family: Urbanist;
     font-style: normal;
     font-display: swap;
     font-weight: 100 900;
@@ -96,7 +96,7 @@ h1, h2, h3, h4, h5, h6 {
 
 /* figtree-latin-wght-normal */
 @font-face {
-    font-family: 'Figtree Variable';
+    font-family: Figtree;
     font-style: normal;
     font-display: swap;
     font-weight: 300 900;

--- a/templates/django_summernote/widget_iframe_editor.html
+++ b/templates/django_summernote/widget_iframe_editor.html
@@ -1,7 +1,7 @@
 {% load static %}
 
 <!DOCTYPE html>
-<html style="font-size: 24px"></htmlstyle>
+<html style="font-size: 18px"></htmlstyle>
     <head>
         <title>django-summernote frame</title>
         {% for url in css %}


### PR DESCRIPTION
1. Add back summernote font dropdown.
2. Fix bleach cleaning to not break when it sees inline fonts families, weights, and sizes (required unescaping double quotes manually to singe quotes.)
3. Include h1-6 in summernote's "Style" dropdown.